### PR TITLE
🔧 Allow deposit with no MyST project pages for single project case

### DIFF
--- a/.changeset/olive-lamps-study.md
+++ b/.changeset/olive-lamps-study.md
@@ -1,0 +1,5 @@
+---
+'zenodo-utils': patch
+---
+
+Allow deposit with no MyST project pages for single project case

--- a/src/cli/deposit.ts
+++ b/src/cli/deposit.ts
@@ -138,27 +138,31 @@ async function getDepositSources(
   projectPath = selectors.selectCurrentProjectPath(state);
   const configFile = selectors.selectCurrentProjectFile(state);
   if (projectPath && configFile) {
-    const project = await processProject(
-      session,
-      { path: projectPath },
-      {
-        imageExtensions: [],
-        writeFiles: false,
-      },
-    );
-    const pages = filterPages(project);
-    if (pages.length === 0) throw new Error('No MyST pages found');
-    const resp = await inquirer.prompt([
-      {
-        name: 'depositFile',
-        type: 'list',
-        message: 'File:',
-        choices: [{ file: configFile }, ...filterPages(project)].map(({ file }) => {
-          return { name: path.relative('.', file), value: file };
-        }),
-      },
-    ]);
-    depositFile = resp.depositFile;
+    try {
+      const project = await processProject(
+        session,
+        { path: projectPath },
+        {
+          imageExtensions: [],
+          writeFiles: false,
+        },
+      );
+      const pages = filterPages(project);
+      if (pages.length === 0) throw new Error('No MyST pages found');
+      const resp = await inquirer.prompt([
+        {
+          name: 'depositFile',
+          type: 'list',
+          message: 'File:',
+          choices: [{ file: configFile }, ...filterPages(project)].map(({ file }) => {
+            return { name: path.relative('.', file), value: file };
+          }),
+        },
+      ]);
+      depositFile = resp.depositFile;
+    } catch (error) {
+      depositFile = configFile;
+    }
     return [{ projectPath, depositFile }];
   }
   // If there is no project on the current path, load all projects in child folders


### PR DESCRIPTION
In #6 I added support for zenodo uploads with `myst.yml` + pdf/ppt/etc - i.e. no md/ipynb files and therefore no ability to do a full myst build. However, this support only applied to the folder-traversal case. If using this command from a single myst folder, the upload still failed.

This PR adds a try-catch which allows single folder uploads to go ahead even if the myst project does not build.